### PR TITLE
fix: invalid topic

### DIFF
--- a/server.js
+++ b/server.js
@@ -91,7 +91,7 @@ function createConnection() {
             JsonDataSetMessageContentMask.MetaDataVersion,
         },
         transportSettings: {
-            queueName: "/opcuaovermqttdemo/temperature",
+            queueName: "opcuaovermqttdemo/temperature",
         },
     };
 


### PR DESCRIPTION
fix: remove leading "/" according to mqtt best practices

> Never use a leading forward slash
> A leading forward slash is permitted in MQTT. For example, /myhome/groundfloor/livingroom. However, the leading forward slash introduces an unnecessary topic level with a zero character at the front. The zero does not provide any benefit and often leads to confusion.

ref: https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices/

usually the queue in pubsub has a generic spec defined structure (optional) -> "prosysopc/json/data/urn:LAPTOP-G69QK496:OPCUA:SimulationServer/WriterGroup1/VariableDataSetWriter"